### PR TITLE
added auto delete

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from discord_slash import SlashCommandOptionType
 from discord_slash.utils import manage_commands
 
 client = discord.Client(intents=discord.Intents.all())
-slash = SlashCommand(client, auto_register=True)
+slash = SlashCommand(client, auto_register=True, auto_delete=True)
 load_dotenv('.env')
 
 guild_ids = [799092380095348736]


### PR DESCRIPTION
added auto delete to delete commands that no longer exist in the bots code, so we don't have people confused, this mainly affects the confusion from when we changed the /addrole and /role commands, the /role command stayed in the slash command directory,